### PR TITLE
feat: Update Agones version and Kubernetes version

### DIFF
--- a/modules/agones/main.tf
+++ b/modules/agones/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "this" {
   repository    = "https://agones.dev/chart/stable"
   name          = "agones"
   chart         = "agones"
-  version       = "1.21.0"
+  version       = "1.23.0"
   wait_for_jobs = true
 
   # Use set block for certificates as yaml multiline string is bothering

--- a/modules/dgs_cluster/main.tf
+++ b/modules/dgs_cluster/main.tf
@@ -48,7 +48,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "18.8.1"
 
-  cluster_version = "1.21"
+  cluster_version = "1.22"
   cluster_name    = var.cluster_name
   vpc_id          = var.vpc.vpc_id
   subnet_ids      = var.vpc.private_subnets

--- a/modules/dgs_cluster/manifests/fleet.yaml
+++ b/modules/dgs_cluster/manifests/fleet.yaml
@@ -22,7 +22,7 @@ spec:
             effect: "NoExecute"
           containers:
           - name: dgs
-            image: gcr.io/agones-images/simple-game-server:0.6
+            image: gcr.io/agones-images/simple-game-server:0.13
             args: ["7654", "true"]
             env:
             resources:

--- a/modules/routing_cluster/main.tf
+++ b/modules/routing_cluster/main.tf
@@ -46,7 +46,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "18.8.1"
 
-  cluster_version = "1.21"
+  cluster_version = "1.22"
   cluster_name    = var.cluster_name
   vpc_id          = var.vpc.vpc_id
   subnet_ids      = var.vpc.private_subnets


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Agones released v1.23.0.
See : https://github.com/googleforgames/agones/releases/tag/v1.23.0
This Agones version supports Kubernetes 1.22.

