### PR TITLE
feat: use graviton2 for game-servers

### DIFF
--- a/modules/agones/main.tf
+++ b/modules/agones/main.tf
@@ -83,7 +83,9 @@ module "agones_system_node_group" {
   min_size               = 1
   max_size               = 10
   desired_size           = 1
-  instance_types         = ["t3.large"]
+  # ami_type               = "AL2_ARM_64"
+  # instance_types         = ["t4g.large"]
+  instance_types = ["t3.medium"]
   subnet_ids             = var.vpc.private_subnets
   vpc_id                 = var.vpc.vpc_id
   vpc_security_group_ids = [var.node_security_group_id]
@@ -131,12 +133,8 @@ module "agones_gameserver_node_group" {
   min_size       = 0
   max_size       = 30
   desired_size   = 0
-  instance_types = ["c5.large"]
-  # To use Graviton2, uncomment lines below.
-  # Note that currently Agones does not support ARM environment, so it won't launch pods.
-  # https://github.com/googleforgames/agones/issues/2216
-  # ami_type = "AL2_ARM_64"
-  # instance_types = ["t4g.medium"]
+  ami_type = "AL2_ARM_64"
+  instance_types = ["t4g.medium"]
 
   subnet_ids = var.vpc.public_subnets
   vpc_id     = var.vpc.vpc_id

--- a/modules/agones/main.tf
+++ b/modules/agones/main.tf
@@ -80,12 +80,12 @@ module "agones_system_node_group" {
   name         = var.namespace
   cluster_name = var.cluster_name
 
-  min_size               = 1
-  max_size               = 10
-  desired_size           = 1
+  min_size     = 1
+  max_size     = 10
+  desired_size = 1
   # ami_type               = "AL2_ARM_64"
   # instance_types         = ["t4g.large"]
-  instance_types = ["t3.medium"]
+  instance_types         = ["t3.medium"]
   subnet_ids             = var.vpc.private_subnets
   vpc_id                 = var.vpc.vpc_id
   vpc_security_group_ids = [var.node_security_group_id]
@@ -133,7 +133,7 @@ module "agones_gameserver_node_group" {
   min_size       = 0
   max_size       = 30
   desired_size   = 0
-  ami_type = "AL2_ARM_64"
+  ami_type       = "AL2_ARM_64"
   instance_types = ["t4g.medium"]
 
   subnet_ids = var.vpc.public_subnets

--- a/modules/routing_cluster/main.tf
+++ b/modules/routing_cluster/main.tf
@@ -101,7 +101,7 @@ module "eks" {
 
   eks_managed_node_groups = {
     default = {
-      desired_size   = 1
+      desired_size = 1
       # ami_type       = "AL2_ARM_64"
       # instance_types = ["t4g.medium"]
       instance_types = ["t3.medium"]

--- a/modules/routing_cluster/main.tf
+++ b/modules/routing_cluster/main.tf
@@ -102,6 +102,8 @@ module "eks" {
   eks_managed_node_groups = {
     default = {
       desired_size   = 1
+      # ami_type       = "AL2_ARM_64"
+      # instance_types = ["t4g.medium"]
       instance_types = ["t3.medium"]
       subnet_ids     = var.vpc.private_subnets
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Agones v1.23.0 now supports ARM architecture.
https://github.com/googleforgames/agones/releases/tag/v1.23.0

So, in this sample, use Graviton2 for game servers.

