### PR TITLE
feat: update Agones and use Graviton2 to all nodes

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,19 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.13.1"
+  version     = "1.14.0"
   constraints = ">= 1.7.0"
   hashes = [
-    "h1:6RC15zES07oX9Ue20RrGlssfVeIqyhcHUvn2dHAMu1E=",
-    "zh:212c030cb975e46e3a85a6850c16773974f4498042a45c73b883b25f6e05962d",
-    "zh:213d1be8a231b04fdc55fd027479dbf0ae5b7ab891804b64f464db771d091ecd",
-    "zh:45f37b5c43f85d79973d0b890f774531a65def7f8436e435a4e259198f1c62de",
-    "zh:5a362871827f8582d6129b9c8b7d73c5e4e181155cef4cba1fe0408880db52db",
-    "zh:78986fdb4c41ac35815e4d41832d24b41b0aac046c046f21db92205115d16bae",
-    "zh:a6d07a9f066c386f44d61e7e2e83133663e3049f5c6b153fa5601b85cbb788b1",
-    "zh:bb307e902d2401df42205d57e36a2e094765b87b12f99a24ec2af411bef3c0fa",
-    "zh:dc3281f9fab38b8daf76d5f0073d2e323574f03d4cef338d6a363380f7f7bb59",
-    "zh:eb30e7fef17e7630858070d23a59375ba3a87fceaffde1c722338b1ad88df568",
+    "h1:mX2AOFIMIxJmW5kM8DT51gloIOKCr9iT6W8yodnUyfs=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
   ]
 }
 
@@ -57,38 +57,41 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 }
 
 provider "registry.terraform.io/hashicorp/helm" {
-  version = "2.4.1"
+  version = "2.5.1"
   hashes = [
-    "h1:CLb4n9f/hLyqqq0zbc+h5SuNOB7KnO65qOOb+ohwsKA=",
-    "zh:07517b24ea2ce4a1d3be3b88c3efc7fb452cd97aea8fac93ca37a08a8ec06e14",
-    "zh:11ef6118ed03a1b40ff66adfe21b8707ece0568dae1347ddfbcff8452c0655d5",
-    "zh:1ae07e9cc6b088a6a68421642c05e2fa7d00ed03e9401e78c258cf22a239f526",
-    "zh:1c5b4cd44033a0d7bf7546df930c55aa41db27b70b3bca6d145faf9b9a2da772",
-    "zh:256413132110ddcb0c3ea17c7b01123ad2d5b70565848a77c5ccc22a3f32b0dd",
-    "zh:4ab46fd9aadddef26604382bc9b49100586647e63ef6384e0c0c3f010ff2f66e",
-    "zh:5a35d23a9f08c36fceda3cef7ce2c7dc5eca32e5f36494de695e09a5007122f0",
-    "zh:8e9823a1e5b985b63fe283b755a821e5011a58112447d42fb969c7258ed57ed3",
-    "zh:8f79722eba9bf77d341edf48a1fd51a52d93ec31d9cac9ba8498a3a061ea4a7f",
-    "zh:b2ea782848b10a343f586ba8ee0cf4d7ff65aa2d4b144eea5bbd8f9801b54c67",
-    "zh:e72d1ccf8a75d8e8456c6bb4d843fd4deb0e962ad8f167fa84cf17f12c12304e",
+    "h1:a9KwjqINdNy6IsEbkHUB1vwvYfy5OJ2VxFL9/NDFLoY=",
+    "zh:140b9748f0ad193a20d69e59d672f3c4eda8a56cede56a92f931bd3af020e2e9",
+    "zh:17ae319466ed6538ad49e011998bb86565fe0e97bc8b9ad7c8dda46a20f90669",
+    "zh:3a8bd723c21ba70e19f0395ed7096fc8e08bfc23366f1c3f06a9107eb37c572c",
+    "zh:3aae3b82adbe6dca52f1a1c8cf51575446e6b0f01f1b1f3b30de578c9af4a933",
+    "zh:3f65221f40148df57d2888e4f31ef3bf430b8c5af41de0db39a2b964e1826d7c",
+    "zh:650c74c4f46f5eb01df11d8392bdb7ebee3bba59ac0721000a6ad731ff0e61e2",
+    "zh:930fb8ab4cd6634472dfd6aa3123f109ef5b32cbe6ef7b4695fae6751353e83f",
+    "zh:ae57cd4b0be4b9ca252bc5d347bc925e35b0ed74d3dcdebf06c11362c1ac3436",
+    "zh:d15b1732a8602b6726eac22628b2f72f72d98b75b9c6aabceec9fd696fda696a",
+    "zh:d730ede1656bd193e2aea5302acec47c4905fe30b96f550196be4a0ed5f41936",
+    "zh:f010d4f9d8cd15936be4df12bf256cb2175ca1dedb728bd3a866c03d2ee7591f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version = "2.8.0"
+  version     = "2.11.0"
+  constraints = ">= 2.10.0"
   hashes = [
-    "h1:tfU8BStZIt2d6KIGTRNjWb09zeVzh3UFGNRGVgFce+A=",
-    "zh:0cf42c17c05ae5f0f5eb4b2c375dd2068960b97392e50823e47b2cee7b5e01be",
-    "zh:29e3751eceae92c7400a17fe3a5394ed761627bcadfda66e7ac91d6485c37927",
-    "zh:2d95584504c651e1e2e49fbb5fae1736e32a505102c3dbd2c319b26884a7d3d5",
-    "zh:4a5f1d915c19e7c7b4f04d7d68f82db2c872dad75b9e6f33a6ddce43aa160405",
-    "zh:4b959187fd2c884a4c6606e1c4edc7b506ec4cadb2742831f37aca1463eb349d",
-    "zh:5e76a2b81c93d9904d50c2a703845f79d2b080c2f87c07ef8f168592033d638f",
-    "zh:c5aa21a7168f96afa4b4776cbd7eefd3e1f47d48430dce75c7f761f2d2fac77b",
-    "zh:d45e8bd98fc6752ea087e744efdafb209e7ec5a4224f9affee0a24fb51d26bb9",
-    "zh:d4739255076ed7f3ac2a06aef89e8e48a87667f3e470c514ce2185c0569cc1fb",
-    "zh:dbd2f11529a422ffd17040a70c0cc2802b7f1be2499e976dc22f1138d022b1b4",
-    "zh:dbd5357082b2485bb9978bce5b6d508d6b431d15c53bfa1fcc2781131826b5d8",
+    "h1:T65SZhN/tQgsAsHe/G5PCgpjofi+aTKPZ+nZg6WOJpc=",
+    "zh:143a19dd0ea3b07fc5e3d9231f3c2d01f92894385c98a67327de74c76c715843",
+    "zh:1fc757d209e09c3cf7848e4274daa32408c07743698fbed10ee52a4a479b62b6",
+    "zh:22dfebd0685749c51a8f765d51a1090a259778960ac1cd4f32021a325b2b9b72",
+    "zh:3039b3b76e870cd8fc404cf75a29c66b171c6ba9b6182e131b6ae2ca648ec7c0",
+    "zh:3af0a15562fcab4b5684b18802e0239371b2b8ff9197ed069ff4827f795a002b",
+    "zh:50aaf20336d1296a73315adb66f7687f75bd5c6b1f93a894b95c75cc142810ec",
+    "zh:682064fabff895ec351860b4fe0321290bbbb17c2a410b62c9bea0039400650e",
+    "zh:70ac914d5830b3371a2679d8f77cc20c419a6e12925145afae6c977c8eb90934",
+    "zh:710aa02cccf7b0f3fb50880d6d2a7a8b8c9435248666616844ba71f74648cddc",
+    "zh:88e418118cd5afbdec4984944c7ab36950bf48e8d3e09e090232e55eecfb470b",
+    "zh:9cef159377bf23fa331f8724fdc6ce27ad39a217a4bae6df3b1ca408fc643da6",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
@@ -111,20 +114,21 @@ provider "registry.terraform.io/hashicorp/time" {
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version     = "3.1.0"
-  constraints = ">= 2.2.0"
+  version     = "3.4.0"
+  constraints = ">= 3.0.0"
   hashes = [
-    "h1:XTU9f6sGMZHOT8r/+LWCz2BZOPH127FBTPjMMEAAu1U=",
-    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
-    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
-    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
-    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
-    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
-    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
-    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
-    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
-    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
-    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
-    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+    "h1:fSRc/OyRitbAST9vE+mEcmgJiDp+Jx8pGPbUUeYEQRc=",
+    "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",
+    "zh:3ebb82cacb677a099de55f844f0d02886bc804b1a2b94441bc40fabcb64d2a38",
+    "zh:436125c2a7e66bc62a4a7c68bdca694f071d7aa894e8637dc83f4a68fe322546",
+    "zh:5f03db9f1d77e8274ff4750ae32d5c16c42b862b06bcb0683e4d733c8db922e4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8190142ae8a539ab34193b7e75da0fa04035d1dcd8af8be94df1eafeeffb44b6",
+    "zh:8cdc7cd9221e27c189e5beaf78462fce4c2edb081f415a1eafc6da2949de31e2",
+    "zh:a5de0f7f5d63c59ebf61d3c1d94040f410665ff0aa04f66674efe24b39a11f94",
+    "zh:a9fce48db3c140cc3e06f8a3c7ef4d36735e457e7660442d6d5dcd2b0781adc3",
+    "zh:beb92de584c790c7c7f047e45ccd22b6ee3263c7b5a91ae4d6882ae6e7700570",
+    "zh:f373f8cc52846fb513f44f468d885f722ca4dc22af9ff1942368cafd16b796b3",
+    "zh:f69627fd6e5a920b17ff423cdbad2715078ca6d13146dc67668795582ab43748",
   ]
 }

--- a/modules/agones/main.tf
+++ b/modules/agones/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "this" {
   repository    = "https://agones.dev/chart/stable"
   name          = "agones"
   chart         = "agones"
-  version       = "1.23.0"
+  version       = "1.24.0-rc"
   wait_for_jobs = true
 
   # Use set block for certificates as yaml multiline string is bothering
@@ -83,9 +83,8 @@ module "agones_system_node_group" {
   min_size     = 1
   max_size     = 10
   desired_size = 1
-  # ami_type               = "AL2_ARM_64"
-  # instance_types         = ["t4g.large"]
-  instance_types         = ["t3.medium"]
+  ami_type               = "AL2_ARM_64"
+  instance_types         = ["t4g.large"]
   subnet_ids             = var.vpc.private_subnets
   vpc_id                 = var.vpc.vpc_id
   vpc_security_group_ids = [var.node_security_group_id]

--- a/modules/agones/manifests/cert.yaml
+++ b/modules/agones/manifests/cert.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - "*.elb.${aws_region}.amazonaws.com"
   secretName: ${allocator_server_cert_name}
+  commonName: allocation-ca
   issuerRef:
     name: selfsigned
     kind: ClusterIssuer

--- a/modules/dgs_cluster/main.tf
+++ b/modules/dgs_cluster/main.tf
@@ -46,7 +46,7 @@ resource "aws_kms_key" "this" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.8.1"
+  version = "18.23.0"
 
   cluster_version = "1.22"
   cluster_name    = var.cluster_name
@@ -107,7 +107,8 @@ module "eks" {
   eks_managed_node_groups = {
     default = {
       desired_size   = 1
-      instance_types = ["t3.medium"]
+      ami_type       = "AL2_ARM_64"
+      instance_types = ["t4g.medium"]
       subnet_ids     = var.vpc.private_subnets
     }
   }

--- a/modules/routing_cluster/main.tf
+++ b/modules/routing_cluster/main.tf
@@ -44,7 +44,7 @@ resource "aws_kms_key" "this" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.8.1"
+  version = "18.23.0"
 
   cluster_version = "1.22"
   cluster_name    = var.cluster_name
@@ -102,9 +102,8 @@ module "eks" {
   eks_managed_node_groups = {
     default = {
       desired_size = 1
-      # ami_type       = "AL2_ARM_64"
-      # instance_types = ["t4g.medium"]
-      instance_types = ["t3.medium"]
+      ami_type       = "AL2_ARM_64"
+      instance_types = ["t4g.medium"]
       subnet_ids     = var.vpc.private_subnets
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Agones 1.24.0-rc  fixed bugs for ARM64.
https://github.com/googleforgames/agones/releases/tag/v1.24.0-rc

I applied Agones 1.24.0-rc to this sample and all pods are working fine!
```
% kubectl get pods -Aallocation-demo-for-agones-on-eks-haru
NAMESPACE              NAME                                                       READY   STATUS    RESTARTS   AGE
agones-system          agones-allocator-585558c895-vmdhd                          1/1     Running   0          13m
agones-system          agones-controller-77dd64f4df-2tdk5                         1/1     Running   0          13m
aws-otel               aws-otel-eks-ci-hh2xl                                      1/1     Running   0          16m
aws-otel               aws-otel-eks-ci-hjbnb                                      1/1     Running   0          12m
aws-otel               aws-otel-eks-ci-rfw5m                                      1/1     Running   0          16m
cert-manager           cert-manager-b7bd7d7fc-rs99q                               1/1     Running   0          17m
cert-manager           cert-manager-cainjector-7bc574d47f-s2vvh                   1/1     Running   0          17m
cert-manager           cert-manager-webhook-5d44dcd484-2htwj                      1/1     Running   0          17m
default                dgs-fleet-vrbx8-69dkn                                      2/2     Running   0          12m
default                dgs-fleet-vrbx8-7tlfl                                      2/2     Running   0          12m
default                dgs-fleet-vrbx8-f8sx8                                      2/2     Running   0          12m
default                dgs-fleet-vrbx8-j95kr                                      2/2     Running   0          5m55s
default                dgs-fleet-vrbx8-vt4wd                                      2/2     Running   0          12m
kube-system            aws-load-balancer-controller-678dd7c6-f9hdt                1/1     Running   0          13m
kube-system            aws-load-balancer-controller-678dd7c6-hqrcb                1/1     Running   0          13m
kube-system            aws-node-9gtbz                                             1/1     Running   0          12m
kube-system            aws-node-bj27t                                             1/1     Running   0          14m
kube-system            aws-node-xf4rx                                             1/1     Running   0          14m
kube-system            cluster-autoscaler-aws-cluster-autoscaler-8c7c56f9-rvrz9   1/1     Running   0          17m
kube-system            coredns-5b6d4bd6f7-7wx6g                                   1/1     Running   0          21m
kube-system            coredns-5b6d4bd6f7-smqvm                                   1/1     Running   0          21m
kube-system            kube-proxy-7jc76                                           1/1     Running   0          16m
kube-system            kube-proxy-g8qnd                                           1/1     Running   0          16m
kube-system            kube-proxy-vws6j                                           1/1     Running   0          12m
kubernetes-dashboard   kubernetes-dashboard-6bdd98d499-w22qb                      2/2     Running   0          17m
logging                fluent-bit-knbs9                                           1/1     Running   0          12m
logging                fluent-bit-r6rd9                                           1/1     Running   0          16m
logging                fluent-bit-z68xn                                           1/1     Running   0          16m
metrics-server         metrics-server-694d47d564-nbr6n                            1/1     Running   0          17m
```
